### PR TITLE
Hook into Hypothesis and icontract

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,4 +21,6 @@ jobs:
         python -m pip install --upgrade pip
         pip install -e .[dev]
     - name: Run pre-commit checks
-      run: python precommit.py
+      run: |
+        python -m doctest icontract_hypothesis/__init__.py
+        python precommit.py

--- a/precommit.py
+++ b/precommit.py
@@ -73,9 +73,9 @@ def main() -> int:
     subprocess.check_call(["coverage", "report"])
 
     print("Doctesting...")
-    subprocess.check_call([sys.executable, "-m", "doctest", "README.rst"])
     for pth in (repo_root / "icontract_hypothesis").glob("**/*.py"):
         subprocess.check_call([sys.executable, "-m", "doctest", str(pth)])
+    subprocess.check_call([sys.executable, "-m", "doctest", "README.rst"])
 
     print("Checking the restructured text of the readme...")
     subprocess.check_call(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-icontract>=2.4.0,<3
-hypothesis>5,<7
+icontract>=2.4.1,<3
+hypothesis>=5,<7

--- a/tests/manually_test_registration.py
+++ b/tests/manually_test_registration.py
@@ -1,0 +1,35 @@
+"""Test that DBC classes are correctly registered with Hypothesis."""
+import unittest
+
+import hypothesis.strategies._internal.types
+
+
+def main() -> None:
+    """Execute the test script."""
+    import icontract
+
+    assert (
+        icontract._metaclass._CONTRACT_CLASSES is not None
+    ), "icontract has been unexpectedly already monkey-patched"
+
+    class A(icontract.DBC):
+        pass
+
+    assert [A] == list(icontract._metaclass._CONTRACT_CLASSES)
+
+    import icontract_hypothesis
+
+    assert not hasattr(
+        icontract._metaclass, "_CONTRACT_CLASSES"
+    ), "Expected _CONTRACT_CLASSES to be deleted upon monkey-patching"
+
+    assert A in hypothesis.strategies._internal.types._global_type_lookup
+
+    class B(icontract.DBC):
+        pass
+
+    assert B in hypothesis.strategies._internal.types._global_type_lookup
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This patch introduces a plug-in with Hypothesis so that `DBC` classes
are automatically registered when Hypothesis is used. To that end, it
hooks into icontract to redirect registrations to Hypothesis global
registry.