### PR TITLE
Improve parsing of Hypothesis settings

### DIFF
--- a/icontract_hypothesis/pyicontract_hypothesis/_test.py
+++ b/icontract_hypothesis/pyicontract_hypothesis/_test.py
@@ -2,13 +2,25 @@
 import argparse
 import collections
 import datetime
+import inspect
 import json
 import pathlib
 import re
 import textwrap
-from typing import Mapping, Any, Tuple, Optional, List, MutableMapping, Dict, TextIO
+from typing import (
+    Mapping,
+    Any,
+    Tuple,
+    Optional,
+    List,
+    MutableMapping,
+    Dict,
+    TextIO,
+)
 
 import hypothesis
+import hypothesis._settings
+import hypothesis.errors
 
 import icontract_hypothesis
 import icontract_hypothesis.pyicontract_hypothesis._general as _general
@@ -18,17 +30,116 @@ class Params:
     """Represent parameters of the command "test"."""
 
     def __init__(
-        self, path: pathlib.Path, settings: Mapping[str, Any], inspect: bool
+        self,
+        path: pathlib.Path,
+        settings_parsing: Optional["SettingsParsing"],
+        do_inspect: bool,
     ) -> None:
         """Initialize with the given values."""
         self.path = path
-        self.settings = settings
-        self.inspect = inspect
+        self.settings_parsing = settings_parsing
+        self.inspect = do_inspect
 
 
 _SETTING_STATEMENT_RE = re.compile(
     r"^(?P<identifier>[a-zA-Z_][a-zA-Z_0-9]*)\s*=\s*(?P<value>.*)\s*$"
 )
+
+_HYPOTHESIS_SETTINGS_PARAMETERS = inspect.signature(
+    hypothesis.settings.__init__
+).parameters
+_HYPOTHESIS_HEALTH_CHECK_MAP = {
+    health_check.name: health_check for health_check in hypothesis.HealthCheck
+}
+_HYPOTHESIS_VERBOSITY_MAP = {
+    verbosity.name: verbosity for verbosity in hypothesis.Verbosity
+}
+_HYPOTHESIS_PHASE_MAP = {phase.name: phase for phase in hypothesis.Phase}
+
+
+class SettingsParsing:
+    """Represent hypothesis.settings such that it can be inspected down the line."""
+
+    def __init__(self, parsed_kwargs: Mapping[str, Any], product: hypothesis.settings):
+        """Initialize with the given values."""
+        self.parsed_kwargs = parsed_kwargs
+        self.product = product
+
+
+def _parse_hypothesis_settings(
+    settings: Mapping[str, Any]
+) -> Tuple[Optional[SettingsParsing], List[str]]:
+    """
+    Try to parse the setting as Hypothesis settings.
+
+    Return (settings, errors if any).
+    """
+    errors = []
+
+    kwargs = collections.OrderedDict()  # type: MutableMapping[str, Any]
+
+    for identifier, value in settings.items():
+        if identifier not in _HYPOTHESIS_SETTINGS_PARAMETERS:
+            errors.append(f"Invalid Hypothesis setting: {identifier!r}")
+        else:
+            if identifier == "verbosity":
+                if value not in _HYPOTHESIS_VERBOSITY_MAP:
+                    errors.append(
+                        f"Invalid Hypothesis setting {identifier!r}: {value!r}"
+                    )
+                else:
+                    kwargs[identifier] = _HYPOTHESIS_VERBOSITY_MAP[value]
+
+            elif identifier == "phase":
+                if not isinstance(value, list):
+                    errors.append(
+                        f"Invalid Hypothesis setting {identifier!r}: "
+                        f"expected a list, but got {value!r}"
+                    )
+                else:
+                    parsed_items = []  # type: List[Any]
+                    for item in value:
+                        if item not in _HYPOTHESIS_PHASE_MAP:
+                            errors.append(
+                                f"Invalid {hypothesis.Phase.__name__} in the Hypothesis setting "
+                                f"{identifier!r}: {item!r}"
+                            )
+                        else:
+                            parsed_items.append(_HYPOTHESIS_PHASE_MAP[item])
+                    kwargs[identifier] = parsed_items
+
+            elif identifier == "suppress_health_check":
+                if not isinstance(value, list):
+                    errors.append(
+                        f"Invalid Hypothesis setting {identifier!r}: "
+                        f"expected a list, but got {value!r}"
+                    )
+                else:
+                    parsed_items = []
+                    for item in value:
+                        if item not in _HYPOTHESIS_HEALTH_CHECK_MAP:
+                            errors.append(
+                                f"Invalid {hypothesis.HealthCheck.__name__} in the setting "
+                                f"{identifier!r}: {item!r}"
+                            )
+                        else:
+                            parsed_items.append(_HYPOTHESIS_HEALTH_CHECK_MAP[item])
+                    kwargs[identifier] = parsed_items
+            else:
+                kwargs[identifier] = value
+
+    if errors:
+        return None, errors
+
+    try:
+        return (
+            SettingsParsing(
+                parsed_kwargs=kwargs, product=hypothesis.settings(**kwargs)
+            ),
+            [],
+        )
+    except hypothesis.errors.InvalidArgument as error:
+        return None, [f"Invalid Hypothesis settings: {error}"]
 
 
 def parse_params(args: argparse.Namespace) -> Tuple[Optional[Params], List[str]]:
@@ -42,6 +153,8 @@ def parse_params(args: argparse.Namespace) -> Tuple[Optional[Params], List[str]]
     path = pathlib.Path(args.path)
 
     settings = collections.OrderedDict()  # type: MutableMapping[str, Any]
+
+    settings_parsing = None  # type: Optional[SettingsParsing]
 
     if args.settings is not None:
         for i, statement in enumerate(args.settings):
@@ -71,14 +184,25 @@ def parse_params(args: argparse.Namespace) -> Tuple[Optional[Params], List[str]]
 
             settings[identifier] = value
 
+        settings_parsing, settings_errors = _parse_hypothesis_settings(
+            settings=settings
+        )
+        if settings_errors:
+            errors.extend(settings_errors)
+        else:
+            assert settings_parsing is not None
+
     if errors:
         return None, errors
 
-    return Params(path=path, settings=settings, inspect=args.inspect), errors
+    return (
+        Params(path=path, settings_parsing=settings_parsing, do_inspect=args.inspect),
+        errors,
+    )
 
 
 def _test_function_point(
-    point: _general.FunctionPoint, settings: Optional[Mapping[str, Any]]
+    point: _general.FunctionPoint, hypothesis_settings: Optional[hypothesis.settings]
 ) -> List[str]:
     """
     Test a single function point.
@@ -104,8 +228,8 @@ def _test_function_point(
         func(**kwargs)
 
     wrapped = hypothesis.given(strategy)(execute)
-    if settings:
-        wrapped = hypothesis.settings(**settings)(wrapped)
+    if hypothesis_settings:
+        wrapped = hypothesis_settings(wrapped)
 
     wrapped()
 
@@ -113,7 +237,7 @@ def _test_function_point(
 
 
 def _inspect_test_function_point(
-    point: _general.FunctionPoint, settings: Optional[Mapping[str, Any]]
+    point: _general.FunctionPoint, settings_parsing: Optional[SettingsParsing]
 ) -> Tuple[str, List[str]]:
     """
     Inspect what test will executed to test a single function point.
@@ -144,27 +268,22 @@ def _inspect_test_function_point(
         ).format(textwrap.indent(str(strategy), "    "))
     ]
 
-    if settings:
-        assert len(settings) != 0
+    if settings_parsing and len(settings_parsing.parsed_kwargs) > 0:
+        if len(settings_parsing.parsed_kwargs) == 1:
+            identifier, value = list(settings_parsing.parsed_kwargs.items())[0]
 
-        if len(settings) == 1:
-            items_lst = list(settings.items())
-            # fmt: off
-            settings_str = ''.join(
-                ['hypothesis.settings({'] +
-                ['{!r}: {!r}'.format(items_lst[0][0], items_lst[0][1])] +
-                ['})']
-            )
-            # fmt: on
+            settings_str = f"hypothesis.settings({identifier}={value})"
         else:
-            settings_parts = ["hypothesis.settings({"]
-            for i, (key, value) in enumerate(settings.items()):
-                if i < len(settings) - 1:
-                    settings_parts.append(f"    {key!r}: {value!r},")
+            lines = ["hypothesis.settings("]
+            items = list(settings_parsing.parsed_kwargs.items())
+            for i, (identifier, value) in enumerate(items):
+                if i < len(items) - 1:
+                    lines.append(f"    {identifier}={value},")
                 else:
-                    settings_parts.append(f"    {key!r}: {value!r}")
-            settings_parts.append("})")
-            settings_str = "\n".join(settings_parts)
+                    lines.append(f"    {identifier}={value}")
+            lines.append(")")
+
+            settings_str = "\n".join(lines)
 
         parts.append(settings_str)
 
@@ -204,7 +323,7 @@ def test(general: _general.Params, command: Params, stdout: TextIO) -> List[str]
         printed_previously = False
         for point in points:
             inspection, test_errors = _inspect_test_function_point(
-                point=point, settings=command.settings
+                point=point, settings_parsing=command.settings_parsing
             )
             errors.extend(test_errors)
 
@@ -219,7 +338,14 @@ def test(general: _general.Params, command: Params, stdout: TextIO) -> List[str]
     else:
         for point in points:
             start = datetime.datetime.now()
-            test_errors = _test_function_point(point=point, settings=command.settings)
+            test_errors = _test_function_point(
+                point=point,
+                hypothesis_settings=(
+                    command.settings_parsing.product
+                    if command.settings_parsing is not None
+                    else None
+                ),
+            )
             errors.extend(test_errors)
 
             duration = datetime.datetime.now() - start


### PR DESCRIPTION
Hypothesis settings can not be simply parsed from JSON, but need to be
mapped to Hypothesis enums and collections of Hypothesis enums.

This patch introduces the necessary parsing of Hypothesis settings.