### PR TITLE
Update `CodeType`s

### DIFF
--- a/icontract_hypothesis/__init__.py
+++ b/icontract_hypothesis/__init__.py
@@ -1042,23 +1042,13 @@ def _rewrite_condition_as_filter(
             lambda_code.co_cellvars,
         )
     else:
-        new_lambda_code = types.CodeType(
-            lambda_code.co_argcount,
-            lambda_code.co_posonlyargcount,
-            lambda_code.co_kwonlyargcount,
-            lambda_code.co_nlocals,
-            lambda_code.co_stacksize,
-            lambda_code.co_flags,
-            new_bytecode.getvalue(),
-            lambda_code.co_consts,
-            contract.condition.__code__.co_names,
-            lambda_code.co_varnames,
-            "<recompiled by icontract-hypothesis>",
-            "<lambda>",
-            lambda_code.co_firstlineno,
-            lambda_code.co_lnotab,
-            contract.condition.__code__.co_freevars,
-            lambda_code.co_cellvars,
+        assert isinstance(lambda_code, types.CodeType)
+        new_lambda_code = lambda_code.replace(
+            co_code=new_bytecode.getvalue(),
+            co_names=contract.condition.__code__.co_names,
+            co_filename="<recompiled by icontract-hypothesis>",
+            co_name="<lambda>",
+            co_freevars=contract.condition.__code__.co_freevars,
         )
 
     recompiled_function = eval(  # pylint: disable=eval-used


### PR DESCRIPTION
`CodeType`s can be updated by using [replace][1] which shortens
the code substantially.

[1]: https://docs.python.org/3/library/types.html#types.CodeType.replace