### PR TITLE
Add `__main__.py`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -242,6 +242,29 @@ that generates a first draft based on pre-conditions that you manually refine fu
 The examples of ghostwritten tests are available at:
 `tests/pyicontract_hypothesis/samples <https://github.com/mristin/icontract-hypothesis/blob/main/tests/pyicontract_hypothesis/samples>`_
 
+Running Tools as Module
+~~~~~~~~~~~~~~~~~~~~~~~
+
+If for some reason you want to run the tools as a module, just invoke:
+
+.. Help starts: python -m icontract_hypothesis --help
+.. code-block::
+
+    usage: icontract_hypothesis [-h] {test,ghostwrite} ...
+
+    Combine property-based testing with contracts of a Python module.
+
+    positional arguments:
+      {test,ghostwrite}  Commands
+        test             Test the functions automatically by inferring search
+                         strategies from preconditions
+        ghostwrite       Ghostwrite the unit tests with inferred search strategies
+
+    optional arguments:
+      -h, --help         show this help message and exit
+
+.. Help ends: python -m icontract_hypothesis --help
+
 Installation
 ------------
 icontract-hypothesis is available on PyPI at

--- a/check_help_in_readme.py
+++ b/check_help_in_readme.py
@@ -41,8 +41,14 @@ def main() -> int:
 
             expected = lines[i + 1 : end_index]
 
+            command_parts = command.split(" ")
+            if command_parts[0] in ["python", "python3"]:
+                # We need to replace "python" with "sys.executable" on Windows as the environment
+                # is not properly inherited.
+                command_parts[0] = sys.executable
+
             proc = subprocess.Popen(
-                command.split(" "),
+                command_parts,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 encoding="utf-8",

--- a/icontract_hypothesis/__main__.py
+++ b/icontract_hypothesis/__main__.py
@@ -1,0 +1,15 @@
+"""Link to the ``pyicontract_hypothesis`` so that you can execute it with ``python`` CLI."""
+
+import sys
+
+import icontract_hypothesis.pyicontract_hypothesis.main
+
+if __name__ == "__main__":
+    sys.exit(
+        icontract_hypothesis.pyicontract_hypothesis.main.run(
+            argv=sys.argv[1:],
+            stdout=sys.stdout,
+            stderr=sys.stderr,
+            prog="icontract_hypothesis",
+        )
+    )

--- a/icontract_hypothesis/pyicontract_hypothesis/main.py
+++ b/icontract_hypothesis/pyicontract_hypothesis/main.py
@@ -59,9 +59,15 @@ def _parse_args_to_params(
     return Params(general=general, command=command), []
 
 
-def _make_argument_parser() -> argparse.ArgumentParser:
-    """Create an instance of the argument parser to parse command-line arguments."""
-    parser = argparse.ArgumentParser(prog="pyicontract-hypothesis", description=__doc__)
+def _make_argument_parser(
+    prog: str = "pyicontract-hypothesis",
+) -> argparse.ArgumentParser:
+    """
+    Create an instance of the argument parser to parse command-line arguments.
+
+    :param prog: name of the program to be displayed in help
+    """
+    parser = argparse.ArgumentParser(prog=prog, description=__doc__)
     subparsers = parser.add_subparsers(help="Commands", dest="command")
     subparsers.required = True
 
@@ -233,9 +239,22 @@ def assert_never(something: NoReturn) -> NoReturn:
     assert False, "Unhandled type: {}".format(type(something).__name__)
 
 
-def run(argv: List[str], stdout: TextIO, stderr: TextIO) -> int:
-    """Execute the run routine."""
-    parser = _make_argument_parser()
+def run(
+    argv: List[str],
+    stdout: TextIO,
+    stderr: TextIO,
+    prog: str = "pyicontract-hypothesis",
+) -> int:
+    """
+    Execute the run routine.
+
+    :param argv: list of command-line arguments
+    :param stdout: stream to write the output to
+    :param stderr: stream to write the error output to
+    :param prog: name of the program to be displayed in help
+    :return: exit code
+    """
+    parser = _make_argument_parser(prog=prog)
     args, out, err = _parse_args(parser=parser, argv=argv)
     if len(out) > 0:
         stdout.write(out)
@@ -279,8 +298,17 @@ def run(argv: List[str], stdout: TextIO, stderr: TextIO) -> int:
 
 
 def entry_point() -> int:
-    """Wrap the entry_point routine wit default arguments."""
-    return run(argv=sys.argv[1:], stdout=sys.stdout, stderr=sys.stderr)
+    """
+    Wrap the entry_point routine wit default arguments.
+
+    :return: exit code
+    """
+    return run(
+        argv=sys.argv[1:],
+        stdout=sys.stdout,
+        stderr=sys.stderr,
+        prog="pyicontract-hypothesis",
+    )
 
 
 if __name__ == "__main__":

--- a/precommit.py
+++ b/precommit.py
@@ -74,6 +74,11 @@ def main() -> int:
 
     print("Doctesting...")
     for pth in (repo_root / "icontract_hypothesis").glob("**/*.py"):
+        # ``__main__.py``'s cause doctest to go banana, so we need to skip them;
+        # see https://stackoverflow.com/questions/58731519/doctest-fails-on-main-py
+        if pth.name == "__main__.py":
+            continue
+
         subprocess.check_call([sys.executable, "-m", "doctest", str(pth)])
     subprocess.check_call([sys.executable, "-m", "doctest", "README.rst"])
 


### PR DESCRIPTION
This patch introduces a `__main__.py` so that we can run the command
as `python icontract_hypothesis ...` or
`python -m icontract_hypothesis ...`. This is necessary in situations
where we have to depend on the interpreter to execute a command line
(*.e.g.*, in PyCharm run configurations).