### PR TITLE
Fix missing strategy if nothing inferred

### DIFF
--- a/icontract_hypothesis/__init__.py
+++ b/icontract_hypothesis/__init__.py
@@ -715,6 +715,7 @@ def _infer_strategy_for_argument(
         return hypothesis.strategies.from_type(type_hint)
 
     strategy = None  # type: Optional[hypothesis.strategies.SearchStrategy[Any]]
+    remaining_contracts = contracts
 
     if type_hint in [
         int,
@@ -746,12 +747,12 @@ def _infer_strategy_for_argument(
             a_type=type_hint, inferred=inferred
         )
 
-    elif type_hint == str:
+    if strategy is None and type_hint == str:
         strategy, remaining_contracts = _infer_str_strategy_from_preconditions(
             arg_name=arg_name, contracts=contracts
         )
 
-    else:
+    if strategy is None:
         strategy = hypothesis.strategies.from_type(type_hint)
         remaining_contracts = contracts
 

--- a/icontract_hypothesis/pyicontract_hypothesis/_test.py
+++ b/icontract_hypothesis/pyicontract_hypothesis/_test.py
@@ -215,12 +215,18 @@ def _test_function_point(
 
     try:
         strategy = icontract_hypothesis.infer_strategy(func=func)
+    except AssertionError:
+        raise
     except Exception as error:
+        error_as_str = str(error)
+        if error_as_str == "":
+            error_as_str = str(type(error))
+
         errors.append(
             (
                 "Inference of the search strategy failed for the function: {}. "
                 "The error was: {}"
-            ).format(func, error)
+            ).format(func, error_as_str)
         )
         return errors
 

--- a/tests/strategy_inference/test_strategy_inference.py
+++ b/tests/strategy_inference/test_strategy_inference.py
@@ -69,6 +69,21 @@ class TestWithInferredStrategies(unittest.TestCase):
 
         icontract_hypothesis.test_with_inferred_strategy(some_func)
 
+    def test_resorting_to_from_type(self) -> None:
+        # We can not handle ``.startswith`` at the moment, so we expect
+        # ``from_type`` Hypothesis strategy followed by a filter.
+        @icontract.require(lambda x: x.startswith("oioi"))
+        def some_func(x: str) -> None:
+            pass
+
+        strategy = icontract_hypothesis.infer_strategy(some_func)
+        self.assertEqual(
+            "fixed_dictionaries({'x': text().filter(lambda x: x.startswith(\"oioi\"))})",
+            str(strategy),
+        )
+
+        # We explicitly do not test with this strategy as it will not pass the health check.
+
     def test_snippet_given(self) -> None:
         @icontract.require(lambda x, y: x < y)
         def some_func(x: float, y: float) -> None:


### PR DESCRIPTION
There was a bug that if no strategy could be inferred by pattern
matching, we did not resort to `from_type` as the basic strategy.

This patch fixes the bug.