### PR TITLE
Fix ghostwriting for functions without contracts

### DIFF
--- a/icontract_hypothesis/pyicontract_hypothesis/_ghostwrite.py
+++ b/icontract_hypothesis/pyicontract_hypothesis/_ghostwrite.py
@@ -212,10 +212,8 @@ def _ghostwrite_test_function(
             """\
             @given(
                 {}
-            )""".format(
-                "\n".join(given_args_lines)
-            )
-        )
+            )"""
+        ).format(_indent_but_first(",\n".join(given_args_lines), level=1))
     else:
         given = textwrap.dedent(
             f"""\
@@ -224,6 +222,9 @@ def _ghostwrite_test_function(
             )"""
         )
 
+    assert not re.match(
+        r"^\s", given
+    ), f"Unexpected whitespace at the begining of given: {given!r}"
     assert not given.endswith("\n")
 
     test_func = textwrap.dedent(

--- a/tests/pyicontract_hypothesis/samples/expected_ghostwrites/for_test_well_formatted_with_two_arguments.py
+++ b/tests/pyicontract_hypothesis/samples/expected_ghostwrites/for_test_well_formatted_with_two_arguments.py
@@ -1,0 +1,25 @@
+"""Test tests.pyicontract_hypothesis.samples.well_formatted_with_two_arguments with inferred Hypothesis strategies."""
+
+import unittest
+
+from hypothesis import given
+
+import tests.pyicontract_hypothesis.samples.well_formatted_with_two_arguments
+
+
+class TestWithInferredStrategies(unittest.TestCase):
+    """Test all functions from tests.pyicontract_hypothesis.samples.well_formatted_with_two_arguments with inferred Hypothesis strategies."""
+
+    def test_add(self) -> None:
+        @given(
+            a=integers(),
+            b=integers()
+        )
+        def execute(kwargs) -> None:
+            tests.pyicontract_hypothesis.samples.well_formatted_with_two_arguments.add(**kwargs)
+
+        execute()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/pyicontract_hypothesis/samples/well_formatted_with_two_arguments.py
+++ b/tests/pyicontract_hypothesis/samples/well_formatted_with_two_arguments.py
@@ -1,0 +1,2 @@
+def add(a: int, b: int) -> int:
+    return a+b

--- a/tests/pyicontract_hypothesis/test_ghostwrite.py
+++ b/tests/pyicontract_hypothesis/test_ghostwrite.py
@@ -9,6 +9,7 @@ import shutil
 import sys
 import tempfile
 import unittest
+from typing import List
 
 from icontract_hypothesis.pyicontract_hypothesis import _general, _ghostwrite, main
 
@@ -309,6 +310,41 @@ class TestGhostwrite(unittest.TestCase):
             )
         )
 
+        expected = expected_pth.read_text()
+        self.assertEqual(expected, stdout.getvalue())
+
+    def test_well_formatted_with_two_arguments(self) -> None:
+        # This test is related to the issue:
+        # https://github.com/mristin/icontract-hypothesis/issues/29
+        # fmt: off
+        argv = [
+            "ghostwrite",
+            "--module",
+            "tests.pyicontract_hypothesis.samples.well_formatted_with_two_arguments",
+            "--explicit"
+        ]
+        # fmt: on
+
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+
+        exit_code = main.run(argv=argv, stdout=stdout, stderr=stderr)
+
+        self.assertEqual("", stderr.getvalue())
+        self.assertEqual(exit_code, 0)
+
+        this_dir = pathlib.Path(os.path.realpath(__file__)).parent
+        expected_pth = (
+            this_dir
+            / "samples"
+            / "expected_ghostwrites"
+            / (
+                "for_{}.py".format(
+                    TestGhostwrite.test_well_formatted_with_two_arguments.__name__
+                )
+            )
+        )
+        expected_pth.write_text(stdout.getvalue())  # TODO: debug
         expected = expected_pth.read_text()
         self.assertEqual(expected, stdout.getvalue())
 


### PR DESCRIPTION
This patch fixes ghostwriting for fuctions that lack the contracts. The
resulting code was previously not syntactically correct.

Fixes #29.