### PR TITLE
Handle `__new__` and forward declarations

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-icontract>=2.4.1,<3
+icontract>=2.5.1,<3
 hypothesis>=5,<7

--- a/tests/strategy_inference/test_strategy_inference.py
+++ b/tests/strategy_inference/test_strategy_inference.py
@@ -7,12 +7,14 @@
 import abc
 import dataclasses
 import enum
+import inspect
 import math
 import re
 import sys
-import textwrap
 import unittest
-from typing import List, NamedTuple, Union, Optional, Any, Mapping
+from typing import List, NamedTuple, Union, Optional, Any, Mapping, cast, Sequence
+
+import typing
 
 if sys.version_info >= (3, 8):
     from typing import TypedDict

--- a/tests_3_7/__init__.py
+++ b/tests_3_7/__init__.py
@@ -1,0 +1,13 @@
+"""
+Test Python 3.7-specific features.
+
+For example, we could not test ``test_strategy_inference_on_forward_declarations`` in Python 3.6 as
+the multiple inheritance of ``icontract.DBC`` and ``Sequance[int]`` caused a meta-class conflict.
+"""
+
+import sys
+
+if sys.version_info < (3, 7):
+    def load_tests(loader, suite, pattern):  # pylint: disable=unused-argument
+        """Ignore all the tests for lower Python versions."""
+        return suite

--- a/tests_3_7/strategy_inference/test_strategy_inference_on_forward_declarations.py
+++ b/tests_3_7/strategy_inference/test_strategy_inference_on_forward_declarations.py
@@ -1,0 +1,88 @@
+# Resolving type hints at runtime is difficult. In particular, ``typing.get_type_hints`` requires
+# the user to specify the global and the local namespace.
+#
+# This makes it almost impossible to infer the type hints which use forward declaration of nested
+# classes, see https://www.python.org/dev/peps/pep-0563/#resolving-type-hints-at-runtime.
+#
+# However, dealing with classes defined in the global space should work OK. The following tests
+# check explicitly that icontract-hypothesis can deal with these cases.
+
+import unittest
+from typing import Sequence
+
+import icontract
+
+import icontract_hypothesis
+
+
+def do_something(a: "A") -> None:
+    pass
+
+
+class A(icontract.DBC):
+    def __init__(self, x: int) -> None:
+        pass
+
+
+class B:
+    def __init__(self, x: int) -> None:
+        self.x = x
+
+    def do_something(self, x1: int) -> "B":
+        return B(x=x1)
+
+
+class C(icontract.DBC, Sequence[int]):
+    @icontract.require(lambda xs: all(x > -(2 ** 63) for x in xs))
+    def __new__(cls, xs: Sequence[int]) -> "C":
+        pass
+
+
+def some_func_on_c(c: C) -> None:
+    pass
+
+
+class TestForwardDeclarations(unittest.TestCase):
+    def test_function(self) -> None:
+        strategy = icontract_hypothesis.infer_strategy(do_something)
+
+        self.assertEqual(
+            "fixed_dictionaries("
+            "{'a': "
+            "fixed_dictionaries({'x': integers()})"
+            ".map(lambda d: A(**d))})",
+            str(strategy),
+        )
+
+        icontract_hypothesis.test_with_inferred_strategy(do_something)
+
+    def test_instance_method(self) -> None:
+        b = B(0)
+
+        strategy = icontract_hypothesis.infer_strategy(b.do_something)
+
+        self.assertEqual(
+            "fixed_dictionaries({'x1': integers()})",
+            str(strategy),
+        )
+
+        icontract_hypothesis.test_with_inferred_strategy(do_something)
+
+    def test_new(self) -> None:
+        strategy = icontract_hypothesis.infer_strategy(some_func_on_c)
+
+        self.assertEqual(
+            "fixed_dictionaries("
+            "{'c': "
+            "fixed_dictionaries("
+            "{'xs': one_of(binary(), lists(integers()))"
+            ".filter(lambda xs: all(x > -(2 ** 63) for x in xs))})"
+            ".map(lambda d: C(**d))})",
+            str(strategy),
+        )
+
+        icontract_hypothesis.test_with_inferred_strategy(do_something)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This patch introduces a couple of fixes that handle forward
declarations.

The patch also introduces a couple of fixes to how `__new__` is
handled in this context as we need to pass over a local namespace
including the class corresponding to `__new__` as it is still
not available in the module. Previously, the forward declarations in
`__new__`, which occur quite often!, could not be resolved by
`typing.get_type_hints`.