### PR TITLE
Change copyright bearer

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 Parquery AG
+Copyright (c) 2020 Marko Ristin <marko@ristin.ch>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
GitHub automatically put Parquery AG as the copyright bearer. This is a
mistake as the module is developed only by Marko Ristin at the moment.

Parquery AG has not been involved in the development at all.