### PR TITLE
Handle contracts on `self` as filters

### DIFF
--- a/tests/pyicontract_hypothesis/test_ghostwrite.py
+++ b/tests/pyicontract_hypothesis/test_ghostwrite.py
@@ -344,7 +344,6 @@ class TestGhostwrite(unittest.TestCase):
                 )
             )
         )
-        expected_pth.write_text(stdout.getvalue())  # TODO: debug
         expected = expected_pth.read_text()
         self.assertEqual(expected, stdout.getvalue())
 


### PR DESCRIPTION
If pre-conditions on `self` (and no other arguments) can not be
satisfied, we can not generate any plausible arguments for the bound
method.