### PR TITLE
Adapt to changed interface in icontract 2.5.2

### DIFF
--- a/icontract_hypothesis/__init__.py
+++ b/icontract_hypothesis/__init__.py
@@ -184,7 +184,7 @@ def _recompute(condition: Callable[..., Any], node: ast.expr) -> Tuple[Any, bool
     """Recompute the value corresponding to the node."""
     recompute_visitor = icontract._recompute.Visitor(
         variable_lookup=icontract._represent.collect_variable_lookup(
-            condition=condition, condition_kwargs=None
+            condition=condition, resolved_kwargs=None
         )
     )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-icontract>=2.5.1,<3
+icontract>=2.5.2,<3
 hypothesis>=5,<7


### PR DESCRIPTION
Icontract 2.5.2 brings about changes to internal interface in
`_recompute` module. This patch propagate the changes to
icontract-hypothesis.