### PR TITLE
Fix failing doctests due to newer Hypothesis

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -77,6 +77,7 @@ precondition:
     ...    some_func(x)
 
     >>> test_some_func()
+    ...
     Traceback (most recent call last):
         ...
     icontract.errors.ViolationError: File <doctest README.rst[4]>, line 2 in <module>:


### PR DESCRIPTION
The output of the previous latest Hypothesis (6.12.0) was ignored during
the doctests, but the output of the current Hypothesis version (6.14.0)
breaks the doctests on the GitHub.

Strangely enough, it does not break on my local machine.