### PR TITLE
Fix failing doctests due to newer icontract

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -80,7 +80,9 @@ precondition:
     Traceback (most recent call last):
         ...
     icontract.errors.ViolationError: File <doctest README.rst[4]>, line 2 in <module>:
-    result > 0: result was -999
+    result > 0:
+    result was -999
+    x was 1
 
 The function ``assume_preconditions`` created by
 ``icontract_hypothesis.make_assume_preconditions`` will reject all the input
@@ -102,7 +104,9 @@ values which do not satisfy the pre-conditions of ``some_func``.
     Traceback (most recent call last):
         ...
     icontract.errors.ViolationError: File <doctest README.rst[10]>, line 2 in <module>:
-    result > 0: result was -999
+    result > 0:
+    result was -999
+    x was 1
 
 Which approach to use depends on how you want to write your tests.
 The first approach, using ``assume_preconditions``, is practical if you already


### PR DESCRIPTION
The icontract 2.5.3 introduces slightly different output. This patch
reflects the changes and updates the Readme accordingly so that the
doctests pass again.